### PR TITLE
Simple grammar fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
             <a class="self" href="./">Beautify, unpack or deobfuscate JavaScript and HTML, make JSON/JSONP readable, etc.</a>
         </p>
         <p>
-            All of the source code is completely free and open, available on the <a href="https://github.com/beautify-web/js-beautify">github</a> under MIT licence,
+            All of the source code is completely free and open, available on <a href="https://github.com/beautify-web/js-beautify">GitHub</a> under MIT licence,
             <br>and we have a command-line version, python library and a <a href="https://npmjs.org/package/js-beautify">node package</a> as well.
         </p>
     </div>


### PR DESCRIPTION
Removed "the" before "GitHub" and changed "github" to "GitHub."